### PR TITLE
Minor updates and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,6 @@ Check solve section for steganography.
 
 - [CTF Field Guide](https://trailofbits.github.io/ctf/) - Field Guide by Trails of Bits.
 - [CTF Resources](http://ctfs.github.io/resources/) -  Start Guide maintained by community.
-- [Damn Vulnerable Web Application](http://www.dvwa.co.uk/) PHP/MySQL web application that is damn vulnerable.
 - [How to Get Started in CTF](https://www.endgame.com/blog/how-get-started-ctf) - Short guideline for CTF beginners by Endgame
 - [IppSec](https://www.youtube.com/channel/UCa6eh7gCkpPo5XXUDfygQQA) - Video tutorials and walkthroughs of popular CTF platforms.
 - [LiveOverFlow](https://www.youtube.com/channel/UClcE-kVhqyiHCcjYwcpfj9w) - Video tutorials on Exploitation.
@@ -371,7 +370,7 @@ Check solve section for steganography.
 
 
 *Self-hosted CTFs*
-
+- [Damn Vulnerable Web Application](http://www.dvwa.co.uk/) - PHP/MySQL web application that is damn vulnerable.
 - [Juice Shop CTF](https://github.com/bkimminich/juice-shop-ctf) - Scripts and tools for hosting a CTF on [OWASP Juice Shop](https://www.owasp.org/index.php/OWASP_Juice_Shop_Project) easily.
 
 ## Websites

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It takes time to build up collection of tools used in CTF and remember them all.
 
 *Tools used for creating CTF challenges*
 
-- [Kali Linux CTF Blueprints](https://doc.lagout.org/security/Packt.Kali.Linux.CTF.Blueprints.Jul.2014.ISBN.1783985984.pdf) - Online book on building, testing, and customizing your own Capture the Flag challenges.
+- [Kali Linux CTF Blueprints](https://www.packtpub.com/eu/networking-and-servers/kali-linux-ctf-blueprints) / [download link](https://mega.nz/#!ijQgQKTY!EvhUfLAm7hvV4eLGEVnRRp-lzn7f7JpmMGEZzf-_Kn0) - Online book on building, testing, and customizing your own Capture the Flag challenges.
 
 
 ## Forensics

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It takes time to build up collection of tools used in CTF and remember them all.
 
 *Tools used for creating CTF challenges*
 
-- [Kali Linux CTF Blueprints](https://www.packtpub.com/eu/networking-and-servers/kali-linux-ctf-blueprints) / [download link](https://mega.nz/#!ijQgQKTY!EvhUfLAm7hvV4eLGEVnRRp-lzn7f7JpmMGEZzf-_Kn0) - Online book on building, testing, and customizing your own Capture the Flag challenges.
+- [Kali Linux CTF Blueprints](https://www.packtpub.com/eu/networking-and-servers/kali-linux-ctf-blueprints) - Online book on building, testing, and customizing your own Capture the Flag challenges.
 
 
 ## Forensics

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Check solve section for steganography.
 - [CTF Resources](http://ctfs.github.io/resources/) -  Start Guide maintained by community.
 - [Damn Vulnerable Web Application](http://www.dvwa.co.uk/) PHP/MySQL web application that is damn vulnerable.
 - [How to Get Started in CTF](https://www.endgame.com/blog/how-get-started-ctf) - Short guideline for CTF beginners by Endgame
+- [IppSec](https://www.youtube.com/channel/UCa6eh7gCkpPo5XXUDfygQQA) - Video tutorials and walkthroughs of popular CTF platforms.
 - [LiveOverFlow](https://www.youtube.com/channel/UClcE-kVhqyiHCcjYwcpfj9w) - Video tutorials on Exploitation.
 - [MIPT CTF](https://github.com/xairy/mipt-ctf) - A small course for beginners in CTFs (in Russian).
 


### PR DESCRIPTION
* Fix broken link for Kali Linux CTF Blueprints (issue #135)
* Add IppSec (issue #131)
* Move DVWA from tutorials to self-hosted as it makes more sense to have it there