### PR TITLE
StegOnline link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Check solve section for steganography.
 - [StegCracker](https://github.com/Paradoxis/StegCracker) - Steganography brute-force utility to uncover hidden data inside files.
 - [stegextract](https://github.com/evyatarmeged/stegextract) - Detect hidden files and text in images.
 - [Steghide](http://steghide.sourceforge.net/) - Hide data in various kind of images.
-- [StegOnline](https://georgeom.net/StegOnline/upload) - Conduct a wide range of image steganography operations, such as concealing/revealing files hidden within bits (open-source).
+- [StegOnline](https://github.com/Ge0rg3/StegOnline) - Conduct a wide range of image steganography operations, such as concealing/revealing files hidden within bits (open-source).
 - [Stegsolve](http://www.caesum.com/handbook/Stegsolve.jar) - Apply various steganography techniques to images.
 - [Zsteg](https://github.com/zed-0xff/zsteg/) - PNG/BMP analysis.
 


### PR DESCRIPTION
The existing StegOnline link (https://georgeom.net/StegOnline/upload) leads to a page with 404.
It would be better to link directly to StegOnline's GitHub link.
The GitHub link also provides access to its web application.