### PR TITLE
link to archived endgame blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Check solve section for steganography.
 
 - [CTF Field Guide](https://trailofbits.github.io/ctf/) - Field Guide by Trails of Bits.
 - [CTF Resources](http://ctfs.github.io/resources/) -  Start Guide maintained by community.
-- [How to Get Started in CTF](https://www.endgame.com/blog/how-get-started-ctf) - Short guideline for CTF beginners by Endgame
+- [How to Get Started in CTF](https://web.archive.org/web/20160308060817/https://www.endgame.com/blog/how-get-started-ctf) - Short guideline for CTF beginners by Endgame
 - [Intro. to CTF Course](https://www.hoppersroppers.org/courseCTF.html) - A free course that teaches beginners the basics of forensics, crypto, and web-ex.
 - [IppSec](https://www.youtube.com/channel/UCa6eh7gCkpPo5XXUDfygQQA) - Video tutorials and walkthroughs of popular CTF platforms.
 - [LiveOverFlow](https://www.youtube.com/channel/UClcE-kVhqyiHCcjYwcpfj9w) - Video tutorials on Exploitation.


### PR DESCRIPTION
The current link `301`-s to an irrelevant blog on `www.elastic.co`