### PR TITLE
Add OopsSec Store to Self-hosted CTFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ Check solve section for steganography.
 *Self-hosted CTFs*
 - [Damn Vulnerable Web Application](http://www.dvwa.co.uk/) - PHP/MySQL web application that is damn vulnerable.
 - [Juice Shop CTF](https://github.com/bkimminich/juice-shop-ctf) - Scripts and tools for hosting a CTF on [OWASP Juice Shop](https://www.owasp.org/index.php/OWASP_Juice_Shop_Project) easily.
+- [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - An intentionally vulnerable e-commerce application built with Next.js.
 
 ## Websites
 


### PR DESCRIPTION
This PR adds [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) to the **Self-hosted CTFs** section.

OopsSec Store is an intentionally vulnerable e-commerce application built with Next.js and React.

The project can be quickly set up using `npx create-oss-store` and provides a production-like application environment with REST APIs.

Repository: https://github.com/kOaDT/oss-oopssec-store
