### PR TITLE
Add Pentest Mindmap — interactive command reference for CTF players

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Check solve section for steganography.
 
 - [CSWSH](http://cow.cat/cswsh.html) - Cross-Site WebSocket Hijacking Tester.
 - [Request Bin](https://requestbin.com/) - Lets you inspect http requests to a particular url.
+- [Pentest Mindmap](https://pentestmindmap.com/en) - Interactive mindmap with 11,600+ pentesting commands across 32 categories. Searchable with one-click copy.
 
 ## Steganography
 


### PR DESCRIPTION
Adding Pentest Mindmap — an interactive web-based mindmap with 11,600+ pentesting commands organized across 32 categories.

A searchable, visual reference tool for pentesters. Commands are organized in a D3.js interactive mindmap covering recon, web hacking, AD, privesc, cloud, post-exploitation, and 26 more categories. Each command includes a description.

Trilingual (EN/FR/ES). Free 7-day trial available.